### PR TITLE
Delete the "ports" key from postgres config

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,8 +8,6 @@ services:
             POSTGRES_PASSWORD: galanonimpassword
         volumes:
             - data:/var/lib/postgresql/data
-        ports: 
-            - "5432:5432"
         networks: 
             - default
     redis:


### PR DESCRIPTION
We don't have to expose postgresql to the outer world. I have had some trouble with that, because I had a postgresql instance on my computer and docker complained that the 5432 port was occupied.

I think that this change may be applied to the `redis` service too.